### PR TITLE
Add search and timeline functionality

### DIFF
--- a/lib/viner/client.rb
+++ b/lib/viner/client.rb
@@ -30,6 +30,11 @@ module Viner
       get('timelines/popular', {}, {})
     end
 
+    def search(username)
+      # GET https://api.vineapp.com/users/search/<username>
+      get("users/search/#{username}", {}, {}).data.records
+    end
+
     # Get Tag
     def tag(tag)
       # GET https://api.vineapp.com/timelines/tags/<tag>
@@ -45,6 +50,12 @@ module Viner
         # GET https://api.vineapp.com/users/me
         get("users/me", {}, {})
       end
+    end
+
+    def timeline(user_id)
+      # GET https://api.vineapp.com/timelines/users/<userid>
+      result = get("timelines/users/#{user_id}", {}, {})
+      return result.data.records if result.success
     end
 
     # Get Single Post

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -67,6 +67,31 @@ describe Viner::Client do
       response = @client.notifications
       response.success.should be_true
     end
+  end
 
+  describe "When not authenticated" do
+    before(:each) do
+      @client = Viner::Client.new
+    end
+
+    it "should return an array of users given an existing username" do
+      response = @client.search('KingBach')
+      response.size.should be > 0
+    end
+
+    it "should return an empty array given an invalid username" do
+      response = @client.search('lkjpoqiwekasdmnbzmxnbca')
+      response.should be_empty
+    end
+
+    it "should return an array of a user's timeline given a valid user id" do
+      response = @client.timeline('931427884873170944')
+      response.should be_instance_of Array
+    end
+
+    it "should return nil given an invalid user id" do
+      response = @client.timeline('936189236128367346123123')
+      response.should eq nil
+    end
   end
 end

--- a/viner.gemspec
+++ b/viner.gemspec
@@ -19,9 +19,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "cucumber"
   s.add_development_dependency "aruba"
 
-  s.add_dependency "rspec"
-  s.add_dependency "cucumber"
-  s.add_dependency "aruba"
   s.add_dependency "unirest"
   s.add_dependency "hashie"
 


### PR DESCRIPTION
This PR adds:
- user search
- timeline functionality 
- removes a redundant dependancies bug in gemspec

You can now do:
`@client.timeline 931427884873170944`
and 
`@client.search 'daz_black'`

Here is a reference to the Vine API for search:
https://github.com/starlock/vino/wiki/API-Reference#user-search

Here is a reference to the Vine API for timeline:
https://github.com/starlock/vino/wiki/API-Reference#get-user-timeline
