### PR TITLE
Replace Unirest with standard Net::HTTP library

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,52 +2,66 @@ PATH
   remote: .
   specs:
     viner (0.0.1)
-      aruba
-      cucumber
+      activesupport
       hashie
-      rspec
-      unirest
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.5)
-    aruba (0.5.3)
-      childprocess (>= 0.3.6)
-      cucumber (>= 1.1.1)
-      rspec-expectations (>= 2.7.0)
+    activesupport (4.2.5)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    aruba (0.14.2)
+      childprocess (~> 0.5.6)
+      contracts (~> 0.9)
+      cucumber (>= 1.3.19)
+      ffi (~> 1.9.10)
+      rspec-expectations (>= 2.99)
+      thor (~> 0.19)
     builder (3.2.2)
-    childprocess (0.3.9)
+    childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
-    cucumber (1.3.10)
+    contracts (0.14.0)
+    cucumber (2.4.0)
       builder (>= 2.1.2)
+      cucumber-core (~> 1.5.0)
+      cucumber-wire (~> 0.0.1)
       diff-lcs (>= 1.1.3)
-      gherkin (~> 2.12)
+      gherkin (~> 4.0)
       multi_json (>= 1.7.5, < 2.0)
-      multi_test (>= 0.0.2)
+      multi_test (>= 0.1.2)
+    cucumber-core (1.5.0)
+      gherkin (~> 4.0)
+    cucumber-wire (0.0.1)
     diff-lcs (1.2.5)
-    ffi (1.9.3)
-    gherkin (2.12.2)
-      multi_json (~> 1.3)
-    hashie (2.0.5)
-    json (1.8.1)
-    mime-types (2.0)
-    multi_json (1.8.2)
-    multi_test (0.0.3)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.7)
-    rspec-expectations (2.14.4)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.4)
-    unirest (1.1.1)
-      addressable (~> 2.3.5)
-      json (~> 1.8.1)
-      rest-client (~> 1.6.7)
+    ffi (1.9.14)
+    gherkin (4.0.0)
+    hashie (3.4.6)
+    i18n (0.7.0)
+    json (1.8.3)
+    minitest (5.9.0)
+    multi_json (1.12.1)
+    multi_test (0.1.2)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    thor (0.19.1)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
@@ -58,3 +72,6 @@ DEPENDENCIES
   cucumber
   rspec
   viner!
+
+BUNDLED WITH
+   1.10.6

--- a/lib/viner.rb
+++ b/lib/viner.rb
@@ -1,8 +1,7 @@
-require 'unirest'
 require 'hashie'
 require File.join(File.dirname(__FILE__), "viner", "request")
 require File.join(File.dirname(__FILE__), "viner", "client")
 
 module Viner
-  ENDPOINT = 'https://api.vineapp.com/'
+  ENDPOINT = 'api.vineapp.com'
 end

--- a/lib/viner/client.rb
+++ b/lib/viner/client.rb
@@ -12,7 +12,7 @@ module Viner
     # Login
     def login(username, password)
       # POST https://api.vineapp.com/users/authenticate
-      result = post('users/authenticate', {}, { username: username, password: password })
+      result = post('/users/authenticate', {}, { username: username, password: password })
       self.user_id = result['data']['userId']
       self.key     = result['data']['key']
       result
@@ -21,53 +21,53 @@ module Viner
     # Logout
     def logout
       # DELETE https://api.vineapp.com/users/authenticate
-      delete('users/authenticate', {}, {})
+      delete('/users/authenticate', {}, {})
     end
 
     # Get Popular
     def popular
       # GET https://api.vineapp.com/timelines/popular
-      get('timelines/popular', {}, {})
+      get('/timelines/popular', {}, {})
     end
 
     def search(username)
       # GET https://api.vineapp.com/users/search/<username>
-      get("users/search/#{username}", {}, {}).data.records
+      get("/users/search/#{username}", {}, {}).data.records
     end
 
     # Get Tag
     def tag(tag)
       # GET https://api.vineapp.com/timelines/tags/<tag>
-      get("timelines/tags/#{tag}", {}, {})
+      get("/timelines/tags/#{tag}", {}, {})
     end
 
     # Get User Data
     def profile(user = nil)
       if user
         # GET https://api.vineapp.com/users/profiles/<userid>
-        get("users/profiles/#{user}", {}, {})
+        get("/users/profiles/#{user}", {}, {})
       else
         # GET https://api.vineapp.com/users/me
-        get("users/me", {}, {})
+        get("/users/me", {}, {})
       end
     end
 
     def timeline(user_id)
       # GET https://api.vineapp.com/timelines/users/<userid>
-      result = get("timelines/users/#{user_id}", {}, {})
+      result = get("/timelines/users/#{user_id}", {}, {})
       return result.data.records if result.success
     end
 
     # Get Single Post
     def posts(post)
       # GET https://api.vineapp.com/timelines/posts/<postid>
-      get("timelines/posts/#{post}", {}, {})
+      get("/timelines/posts/#{post}", {}, {})
     end
 
     # Get Notifications
     def notifications
       # GET https://api.vineapp.com/users/<userid>/pendingNotificationsCount
-      get("users/#{@user_id}/pendingNotificationsCount", {}, {})
+      get("/users/#{@user_id}/pendingNotificationsCount", {}, {})
     end
 
   end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -10,12 +10,12 @@ describe Viner::Client do
 
     it "should login" do
       response = @client.login(VINE_USERNAME, VINE_PASSWORD)
-      response.success.should be_true
+      response.success.should be true
     end
 
     it "should not login" do
       response = @client.login('fake', 'fake')
-      response.success.should be_false
+      response.success.should be false
     end
 
   end
@@ -28,7 +28,7 @@ describe Viner::Client do
     it "should logout" do
       @client.login(VINE_USERNAME, VINE_PASSWORD)
       response = @client.logout
-      response.success.should be_true
+      response.success.should be true
     end
   end
 
@@ -40,32 +40,32 @@ describe Viner::Client do
 
     it "should give popular vines" do
       response = @client.popular
-      response.success.should be_true
+      response.success.should be true
     end
 
     it "should give vines by tag" do
       response = @client.tag("cats")
-      response.success.should be_true
+      response.success.should be true
     end
 
     it "should give back my profile" do
       response = @client.profile
-      response.success.should be_true
+      response.success.should be true
     end
 
     it "should give a users profile" do
       response = @client.profile(912392711326285824)
-      response.success.should be_true
+      response.success.should be true
     end
 
     it "should get a single post" do
-      response = @client.posts(255)
-      response.success.should be_true
+      response = @client.posts(1394724251034185728)
+      response.success.should be true
     end
 
     it "should get your notifications" do
       response = @client.notifications
-      response.success.should be_true
+      response.success.should be true
     end
   end
 
@@ -86,7 +86,7 @@ describe Viner::Client do
 
     it "should return an array of a user's timeline given a valid user id" do
       response = @client.timeline('931427884873170944')
-      response.should be_instance_of Array
+      response.should be_instance_of Hashie::Array
     end
 
     it "should return nil given an invalid user id" do

--- a/viner.gemspec
+++ b/viner.gemspec
@@ -18,9 +18,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec"
   s.add_development_dependency "cucumber"
   s.add_development_dependency "aruba"
-
-  s.add_dependency "unirest"
   s.add_dependency "hashie"
+  s.add_dependency "activesupport"
 
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files`.split("\n").map{|f| f =~ /^bin\/(.*)/ ? $1 : nil}.compact


### PR DESCRIPTION
This gem is now broken as Unirest no longer works for making calls to the Vine API. 
This PR:
* Replaces Unirest with standard Net::HTTP library
* Fixes all broken tests 